### PR TITLE
まさしく削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ Test textlint rule by [textlint-tester](https://github.com/textlint/textlint-tes
 | 一先ず | ひとまず |
 | 独りでに | ひとりでに |
 | 殆ど | ほとんど |
-| 正しく | まさしく |
 | 正に | まさに |
 | 況して | まして |
 | 先ず | まず |

--- a/dict/fukushi.yml
+++ b/dict/fukushi.yml
@@ -818,21 +818,6 @@ dict:
         reading: "ホトンド"
         pronunciation: "ホトンド"
   -
-    expected: まさしく
-    extensions: {}
-    tokens:
-      -
-        surface_form: "正しく"
-        pos: "副詞"
-        pos_detail_1: "一般"
-        pos_detail_2: "*"
-        pos_detail_3: "*"
-        conjugated_type: "*"
-        conjugated_form: "*"
-        basic_form: "正しく"
-        reading: "マサシク"
-        pronunciation: "マサシク"
-  -
     expected: まさに
     extensions: {}
     tokens:

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -96,17 +96,6 @@ tester.run("rule", rule, {
         },
         // custom dictionary
         {
-            text: "正しく記載されていなかった。",
-            output: "まさしく記載されていなかった。",
-            errors: [
-                {
-                    message: "ひらがなで表記したほうが読みやすい副詞: \"正しく\" => \"まさしく\"",
-                    line: 1,
-                    column: 1
-                }
-            ]
-        },
-        {
             text: "僕は生憎風流人よりもずつと多慾に生まれついてゐる。",
             output: "僕はあいにく風流人よりもずつと多慾に生まれついてゐる。",
             options: {


### PR DESCRIPTION
https://github.com/kujirahand/nadesiko3/blob/d069000e1df621e3576ef7f79e68542690bb1410/README.md?plain=1#L116
https://github.com/kujirahand/nadesiko3/blob/d069000e1df621e3576ef7f79e68542690bb1410/doc/plugins.md?plain=1#L161
https://github.com/kujirahand/nadesiko3/blob/38bb436bcabcf112c981108cfa6e100ca56cfb8c/doc/win32.md?plain=1#L40

上記のように `正しく` を `ただしく` と読むのが正しい場合でも `まさしく` と誤って形態素解析されてしまうようなので、 `まさしく` をデフォルトのルールから削除します。